### PR TITLE
Add possibility to pass extra arguments to the inference function

### DIFF
--- a/patched_yolo_infer/elements/CropElement.py
+++ b/patched_yolo_infer/elements/CropElement.py
@@ -32,10 +32,10 @@ class CropElement:
         self.detected_masks_real = None # List of np arrays containing masks in case of yolo-seg with the size of source_image_resized or source_image
         self.detected_polygons_real = None # List of polygons points in case of using memory optimaze in values from source_image_resized or source_image
 
-    def calculate_inference(self, model, imgsz=640, conf=0.35, iou=0.7, segment=False, classes_list=None, memory_optimize=False):
+    def calculate_inference(self, model, imgsz=640, conf=0.35, iou=0.7, segment=False, classes_list=None, memory_optimize=False, extra_args=None):
 
         # Perform inference
-        predictions = model.predict(self.crop, imgsz=imgsz, conf=conf, iou=iou, classes=classes_list, verbose=False)
+        predictions = model.predict(self.crop, imgsz=imgsz, conf=conf, iou=iou, classes=classes_list, verbose=False, **extra_args)
 
         pred = predictions[0]
 

--- a/patched_yolo_infer/elements/CropElement.py
+++ b/patched_yolo_infer/elements/CropElement.py
@@ -35,6 +35,7 @@ class CropElement:
     def calculate_inference(self, model, imgsz=640, conf=0.35, iou=0.7, segment=False, classes_list=None, memory_optimize=False, extra_args=None):
 
         # Perform inference
+        extra_args = {} if extra_args is None else extra_args
         predictions = model.predict(self.crop, imgsz=imgsz, conf=conf, iou=iou, classes=classes_list, verbose=False, **extra_args)
 
         pred = predictions[0]

--- a/patched_yolo_infer/nodes/MakeCropsDetectThem.py
+++ b/patched_yolo_infer/nodes/MakeCropsDetectThem.py
@@ -68,7 +68,8 @@ class MakeCropsDetectThem:
         show_crops=False,
         resize_initial_size=False,
         model=None,
-        memory_optimize=True
+        memory_optimize=True,
+        inference_extra_args=None,
     ) -> None:
         if model is None:
             self.model = YOLO(model_path)  # Load the model from the specified path
@@ -89,6 +90,7 @@ class MakeCropsDetectThem:
         self.resize_initial_size = resize_initial_size  # slow operation !
         self.memory_optimize = memory_optimize # memory opimization option for segmentation
         self.class_names_dict = self.model.names
+        self.inference_extra_args = inference_extra_args
 
         self.crops = self.get_crops_xy(
             self.image,
@@ -199,7 +201,8 @@ class MakeCropsDetectThem:
                 iou=self.iou,
                 segment=self.segment,
                 classes_list=self.classes_list,
-                memory_optimize=self.memory_optimize
+                memory_optimize=self.memory_optimize,
+                extra_args=self.inference_extra_args
             )
             crop.calculate_real_values()
             if self.resize_initial_size:


### PR DESCRIPTION
If you want to pass extra options to the inference function, with these changes, you can pass them to the constructor of MakeCropsDetectThem. 

One of the intresting options for this project might be `retina_masks`, which improves the quality of the masks (and maybe polygons?)

Usage example:
```
element_crops = MakeCropsDetectThem(
        image=frame,
        inference_extra_args={
            'retina_masks': True
        }
    )
```

For a list of extra arguments you can pass to the inference function: [https://docs.ultralytics.com/modes/predict/#inference-arguments](url)

Let me know if you'll consider merging this, then I'll also add some documentation in the readme in this PR.